### PR TITLE
dao.7energy.at

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Dafür war es notwendig, dass so ziemlich jedes neue Mitglied erst nach einen pe
 
 Wir bekamen für dieses Projekt auch eine Förderung durch die [Internet Stiftung - netidee](https://www.netidee.at/7energy).&#x20;
 
-Die Dokumentation zu der "Version 1" von 7Energy findest du [hier](https://dao-docs.7energy.at/) und den Zugriff auf die DAO findest du [hier](https://dao.7energy.at/).&#x20;
+Die Dokumentation zu der "Version 1" von 7Energy findest du [hier](https://dao-docs.7energy.at/) und die Webseite findest du [hier](https://7energy.at/).&#x20;


### PR DESCRIPTION
https://dao.7energy.at/ zeigt derzeit auf die Web 7energy.at Webseite, allerdings ohne SSL Zertifikat.

Ich habe den verweis auf die DAO entfernt.
Alternativ kann man sich auch um das SSL zertifikat kümmern,
dann bitte Pull request nicht mergen und schliessen,.